### PR TITLE
Revert "Add the guide release date"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,6 @@
 :projectid: rest-hateoas
 :page-layout: guide
 :page-duration: 30 minutes
-:page-date: 2017-09-19
 :page-description: Learn how to build a hypermedia-driven RESTful web service
 :page-tags: ['REST', 'HATEOAS']
 :page-permalink: /guides/{projectid}


### PR DESCRIPTION
Reverts OpenLiberty/guide-rest-hateoas#13

`page-date` is causing Jekyll build to break.  Another Asciidoctor attribute will be needed to replace `page-date`.  Until we have the new attribute, revert the introduction of `page-date`.